### PR TITLE
confDirName is never assigned

### DIFF
--- a/src/main/java/foundation/privacybydesign/common/BaseConfiguration.java
+++ b/src/main/java/foundation/privacybydesign/common/BaseConfiguration.java
@@ -32,7 +32,7 @@ public class BaseConfiguration<T>  {
     public static BaseConfiguration instance;
 
     private static URI confPath;
-    private static String confDirName;
+    private static String confDirName = "irma_api_server";
 
     public static void load() {
         try {


### PR DESCRIPTION
The instructions at https://github.com/privacybydesign/irma_api_server#configuring-the-server-without-docker don't work because the value confDirName is never assigned a value, resulting in it looking for places like `/etc/null` instead of `/etc/irma_api_server`.